### PR TITLE
Matching arguments in histoneHMM_call_differential and get.differential.regions

### DIFF
--- a/R/highlevel.R
+++ b/R/highlevel.R
@@ -403,7 +403,7 @@ plot.bivariate <- function(fname1, fname2, outdir, sample1, sample2, maxq=1-1e-3
   }
 }
 
-get.differential.regions <- function(fname1, fname2, outdir, sample1, sample2, chrom="chr19", em=FALSE, baum.welch=FALSE, maxq=1-1e-4) {
+get.differential.regions <- function(fname1, fname2, outdir, sample1, sample2, chrom="chr19", em=FALSE, baum.welch=FALSE, maxq=1-1e-4, cutoff=0.5) {
   dir.create(outdir)
   outname = paste(sample1, "-vs-", sample2, sep="")
   fname = paste(outdir, "/", outname, ".txt", sep="")
@@ -420,13 +420,13 @@ get.differential.regions <- function(fname1, fname2, outdir, sample1, sample2, c
   }
   
   if (do.calls) {
-    unmod.both = callRegions(bivariate.posterior, 0.5, "unmod.both", NULL)
+    unmod.both = callRegions(bivariate.posterior, cutoff, "unmod.both", NULL)
     GR2gff(unmod.both, paste(outdir, "/", outname, "-unmod_both.gff", sep=""))
-    mod.both = callRegions(bivariate.posterior, 0.5, "mod.both", NULL)
+    mod.both = callRegions(bivariate.posterior, cutoff, "mod.both", NULL)
     GR2gff(mod.both, paste(outdir, "/", outname, "-mod_both.gff", sep=""))
-    sample1.regions = callRegions(bivariate.posterior, 0.5, make.names(sample1), NULL)
+    sample1.regions = callRegions(bivariate.posterior, cutoff, make.names(sample1), NULL)
     GR2gff(sample1.regions, paste(outdir, "/", outname, "-", sample1, ".gff", sep=""))
-    sample2.regions = callRegions(bivariate.posterior, 0.5, make.names(sample2), NULL)
+    sample2.regions = callRegions(bivariate.posterior, cutoff, make.names(sample2), NULL)
     GR2gff(sample2.regions, paste(outdir, "/", outname, "-", sample2, ".gff", sep=""))
   }
   

--- a/inst/bin/histoneHMM_call_differential.R
+++ b/inst/bin/histoneHMM_call_differential.R
@@ -19,6 +19,9 @@ option_list <- list(
               help="name of sample2 [default \"sample2\"]"),
   make_option("--verbose", action="store_true", default=FALSE,
               help="more output"),
+  make_option("--baumwelch", action="store_false",
+              help="Whether the Baum Welch algorithm should be used for
+                    parameter estimation.")
   make_option(c("-P", "--probability"), default=0.5,
               help="threhshold for the posterior probability to call regions")
 )
@@ -44,4 +47,5 @@ fname2 = opt$args[2]
 ## run the HMM
 regions = get.differential.regions(fname1, fname2, outdir=opt$options$outdir,
   sample1=opt$options$sample1, sample2=opt$options$sample2,
-  em=opt$options$em, maxq=1-1e-3)
+  em=opt$options$em, maxq=1-1e-3, baum.welch=opt$options$baumwelch,
+  cutoff=opt$options$probability)


### PR DESCRIPTION
Currently, the `-P` argument in `histoneHMM_call_differential` is not implemented by `get.differential.regions`, while the `baum.welch` argument in `get.differential.regions` is not implemented in `histoneHMM_call_differential`. This edit makes sure both arguments are implemented in both. I am leaving off `chrom` as I am not completely sure of its purpose, or its necessity in human data.